### PR TITLE
feat: add hard refresh detection service

### DIFF
--- a/src/app/hard-refresh.service.spec.ts
+++ b/src/app/hard-refresh.service.spec.ts
@@ -1,0 +1,38 @@
+import { TestBed } from '@angular/core/testing';
+import { HardRefreshService } from './hard-refresh.service';
+
+describe('HardRefreshService', () => {
+  let originalGetEntriesByType: typeof performance.getEntriesByType;
+  let originalNavigation: any;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    originalGetEntriesByType = performance.getEntriesByType.bind(performance);
+    originalNavigation = (performance as any).navigation;
+  });
+
+  afterEach(() => {
+    performance.getEntriesByType = originalGetEntriesByType;
+    (performance as any).navigation = originalNavigation;
+  });
+
+  it('detects hard refresh via PerformanceNavigationTiming', () => {
+    performance.getEntriesByType = () => [{ type: 'reload' } as PerformanceNavigationTiming];
+    const service = TestBed.inject(HardRefreshService);
+    expect(service.isHardRefresh()).toBeTrue();
+  });
+
+  it('detects normal navigation via PerformanceNavigationTiming', () => {
+    performance.getEntriesByType = () => [{ type: 'navigate' } as PerformanceNavigationTiming];
+    const service = TestBed.inject(HardRefreshService);
+    expect(service.isHardRefresh()).toBeFalse();
+  });
+
+  it('falls back to legacy performance.navigation API', () => {
+    performance.getEntriesByType = () => [] as PerformanceNavigationTiming[];
+    (performance as any).navigation = { type: 1 };
+    const service = TestBed.inject(HardRefreshService);
+    expect(service.isHardRefresh()).toBeTrue();
+  });
+});
+

--- a/src/app/hard-refresh.service.ts
+++ b/src/app/hard-refresh.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@angular/core';
+
+/**
+ * Service to detect whether the current page was loaded through a hard refresh
+ * (e.g. user pressed F5, Ctrl‑R, etc.) or through normal navigation such as
+ * following a link or routing within the SPA.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class HardRefreshService {
+  private readonly hardRefresh: boolean;
+
+  constructor() {
+    this.hardRefresh = this.detectHardRefresh();
+  }
+
+  /**
+   * Determines if the current load was triggered by a browser reload.
+   */
+  private detectHardRefresh(): boolean {
+    if (typeof performance !== 'undefined') {
+      const [navigationEntry] =
+        (performance.getEntriesByType('navigation') as PerformanceNavigationTiming[]);
+      if (navigationEntry) {
+        return navigationEntry.type === 'reload';
+      }
+
+      // Fallback for browsers implementing the older PerformanceNavigation API
+      const legacyNav = (performance as any).navigation as
+        | { type: number }
+        | undefined;
+      if (legacyNav) {
+        // 1 corresponds to TYPE_RELOAD
+        return legacyNav.type === 1;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Indicates whether the page was loaded because the user reloaded the browser.
+   */
+  public isHardRefresh(): boolean {
+    return this.hardRefresh;
+  }
+}
+


### PR DESCRIPTION
## Summary
- detect hard browser refreshes by inspecting `PerformanceNavigationTiming` entries with a legacy fallback
- add unit tests covering reload, normal navigation and fallback cases

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6890aedca5208320ad9a2a5090eef29b